### PR TITLE
Small changes

### DIFF
--- a/extensions/roc-plugin-repo/package.json
+++ b/extensions/roc-plugin-repo/package.json
@@ -58,7 +58,6 @@
     "resolve": "^1.3.3",
     "rimraf": "^2.5.4",
     "roc": "^1.0.0-rc.16",
-    "roc-package-module-dev": "^1.0.0-beta.3",
     "roc-plugin-babel": "^1.0.0-beta.4",
     "semver": "^5.3.0",
     "signal-exit": "^3.0.2",

--- a/extensions/roc-plugin-repo/src/commands/release.js
+++ b/extensions/roc-plugin-repo/src/commands/release.js
@@ -444,6 +444,7 @@ export default projects => ({
                     project.tag,
                     token,
                     draft,
+                    !!prerelease,
                   ),
                 ),
               );
@@ -454,6 +455,7 @@ export default projects => ({
               ctx.releaseTag,
               token,
               draft,
+              !!prerelease,
             );
           },
         },

--- a/extensions/roc-plugin-repo/src/commands/release.js
+++ b/extensions/roc-plugin-repo/src/commands/release.js
@@ -246,7 +246,7 @@ export default projects => ({
         {
           title: 'Building',
           task: () =>
-            execute(`roc repo build ${toRelease}`, {
+            execute(`NODE_ENV=production roc repo build ${toRelease}`, {
               silent: true,
               context: context.directory,
             }),

--- a/extensions/roc-plugin-repo/src/commands/test.js
+++ b/extensions/roc-plugin-repo/src/commands/test.js
@@ -16,6 +16,9 @@ export default projects => ({
     return log.warn('No projects were found');
   }
 
+  // Enforce test
+  process.env.NODE_ENV = 'test';
+
   process.env.ROC_INITAL_ARGV = JSON.stringify(process.argv);
 
   let argv = [...extraArguments];

--- a/extensions/roc-plugin-repo/src/commands/utils/createGitHubRelease.js
+++ b/extensions/roc-plugin-repo/src/commands/utils/createGitHubRelease.js
@@ -10,6 +10,7 @@ export default function createGitHubRelease(
   tag,
   AUTH_TOKEN,
   draft = true,
+  prerelease = false,
 ) {
   const repoInfo = getPkgRepo(packageJSON);
   const browse = url.parse(repoInfo.browse());
@@ -39,5 +40,6 @@ export default function createGitHubRelease(
     name: tag,
     body: text,
     draft,
+    prerelease,
   });
 }

--- a/extensions/roc-plugin-repo/src/index.js
+++ b/extensions/roc-plugin-repo/src/index.js
@@ -3,6 +3,7 @@ import * as validators from 'roc/validators';
 import log from 'roc/log/default/small';
 import readPkg from 'read-pkg';
 import { lazyFunctionRequire, generateDependencies } from 'roc';
+import glob from 'glob';
 
 import { invokeHook, packageJSON } from './util';
 import { config, meta } from './config';
@@ -126,10 +127,17 @@ module.exports.roc = {
         }
 
         // Look for things in either of these directories
-        return settings.repo.mono.reduce(
-          (previous, dir) => previous.concat(getProjects(directory, dir)),
-          [],
-        );
+        return settings.repo.mono.reduce((previous, dir) => {
+          const explodedPaths = glob.sync(dir, {
+            cwd: directory,
+          });
+          return previous.concat(
+            explodedPaths.reduce(
+              (prev, d) => prev.concat(getProjects(directory, d)),
+              [],
+            ),
+          );
+        }, []);
       },
     },
     {


### PR DESCRIPTION
This PR changes the following things in `roc-plugin-repo`.

- Do GitHub release as prerelease if in prerelease
- Support glob pattern in settings for mono, makes it possible to have more complex folder structures
- Remove unused dependency
- Use `NODE_ENV=production` when building for release
- Enforce NODE_ENV=test when running tests